### PR TITLE
Fix for Search results and carousel are overlapping over each other.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -236,6 +236,7 @@ body::-webkit-scrollbar-thumb {
     border-radius: 10px;
     padding: 1rem;
     display: none;
+    z-index: 10;
   }
   .search-results p{
     border-bottom: 1px solid #c2c1c1;


### PR DESCRIPTION
Added z index to `.css` file containing search results

closes #415 