### PR TITLE
Fixed the buttons for carousel and letter color in dark mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "liveServer.settings.port": 5501
+    "liveServer.settings.port": 5502
 }

--- a/index.html
+++ b/index.html
@@ -10578,6 +10578,7 @@ Power usually wears the standard dress shirt, tie, and slacks required of Public
             let toggle = document.querySelector(".navbar-toggler");
             const btn = document.getElementById('btn');
             let themeIcon = document.getElementById("themeIcon");
+            const brandLetters = document.getElementById("animation");
 
             if (btn.classList.contains("btn-outline-dark")) {
                 btn.classList.remove("btn-outline-dark");
@@ -10597,6 +10598,7 @@ Power usually wears the standard dress shirt, tie, and slacks required of Public
             }
 
             element.classList.toggle("dark-mode");
+            brandLetters.classList.toggle("brand-dark");
         }
 
         const swiper = new Swiper('.swiper', {

--- a/styles.css
+++ b/styles.css
@@ -714,7 +714,7 @@ ul.navbar-nav.mr-auto {
   .swiper-button-next::after,
   .swiper-button-prev::after {
     color: #fff;
-    font-size: 12px;
+    font-size: 25px !important;
   }
   
   .swiper-button-next {
@@ -972,6 +972,13 @@ section, .animepediaFooter {
       transform: translate(-150px, -50px) rotate(-180deg) scale(3);
       animation: revolveScale .4s forwards;
     }
+    .brand-dark{
+      color: white;
+    }
+    .brand-dark span{
+      color: white;
+    }
+    
     
     @keyframes revolveScale {
       60% {


### PR DESCRIPTION
The buttons for carousel had no padding, so looked odd. Fixed the font-size of the button to  match.

Also changed the brand letter colors to white for the dark mode.

![image](https://user-images.githubusercontent.com/55879630/198882242-7db9541a-bb32-4c5d-9611-8411126b1d86.png)

Have a look at the buttons for change.

![image](https://user-images.githubusercontent.com/55879630/198882267-8d2f7f95-4bcd-4169-9769-2b0f9e629fa1.png)

The AnimePedia letters were black in Dark mode, which I think in not well distinguished  from the background.
